### PR TITLE
[DO NOT MERGE] This is just for my own perusal

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,8 +40,7 @@ Version 1.10.0 (14 April 2019)
 * Raised default BANDWIDTH_LIMIT from 2MB to 8MB (8000000 bytes).  This is
   because very busy BCH wallets with huge histories would need a higher limit.
   Note the limit is a soft limit in bytes per hour, and it is not catastrophic
-  to send a client 8MB in 1 hour.  Also note that ElectrumX currently does
-  nothing with this limit despite what the documentation claims. (cculianu)
+  to send a client 8MB in 1 hour. (cculianu)
 
 
 Version 1.9.4 (7 Feb 2019)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,39 @@
 .. note:: The primary difference between this and the official ElectrumX
    is that this version supports any block ordering (including the lexically-
    ordered blocks that can be created/followed by several Bitcoin Cash node
-   implementations: ABC, BU, XT, bchd, bcash, Bitprim, and others.)
+   implementations: ABC, BU, XT, bchd, bcash, Bitprim, and others.). We also
+   employ a different anti-phishing strategy than they do, based on a
+   community-maintained blacklist.json file as well as manual banning
+   to supplement that via the banip command. We also have slightly more
+   generous limits to things like MAX_SEND and MAX_SUBS than the defaults
+   of ElectrumX.  We also don't implement their newest cost control logic which
+   we feel is too restrictive for normal BCH usage of the server.
+
+
+Version 1.10.0 (14 April 2019)
+==============================
+
+* Added banip, unbanip, banhost, unbanhost and listbanned rpc commands (cculianu)
+* Disallow multiple servers from same IP to appear in peers (doesn't apply
+  to Tor, however) (cculianu)
+* Limit client connections per IP to 50 by default (MAX_SESSIONS_PER_IP)
+  to prevent the "clients exhausting FDs on server" attack vector.
+  (cculianu)
+* Added blacklist.json mechanism for downloading a community maintained
+  list of bad peers as an anti-phishing, anti-sybil attack measure.
+  Use BLACKLIST_URL="" in env to disable, but it is recommended you leave
+  it enabled.  We use our own file format for this but the code for this
+  subsystem also understand the ElectrumX 1.10.0 format as well. (cculianu)
+* Set MAX_SEND to 4000000 (4MB) by default (was originally 1MB which fails
+  on some BCH wallets). (cculianu)
+* Raised server limit from 250,000 subs to 1,000,000 subs by default
+  (corresponds to env var MAX_SUBS) (cculianu)
+* Raised default BANDWIDTH_LIMIT from 2MB to 8MB (8000000 bytes).  This is
+  because very busy BCH wallets with huge histories would need a higher limit.
+  Note the limit is a soft limit in bytes per hour, and it is not catastrophic
+  to send a client 8MB in 1 hour.  Also note that ElectrumX currently does
+  nothing with this limit despite what the documentation claims. (cculianu)
+
 
 Version 1.9.4 (7 Feb 2019)
 ============================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
-VERSION="ElectronX 1.9.4"
+VERSION="ElectronX 1.10.0"
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -221,7 +221,9 @@ These environment variables are optional:
   list.  Care has been taken so that this file's ban lists do not conflict
   with whatever you specify via the rpc 'banip' or 'banhost' commands.
   Set this to the empty string `""` to disable this feature. Defaults to:
-  `https://www.c3-soft.com/downloads/BitcoinCash/Electron-Cash/blacklist.json`.
+  `https://raw.githubusercontent.com/Electron-Cash/electronx-blacklist/master/blacklist.json`.
+  (If you would like to contribute to this blacklist please visit:
+  https://github.com/Electron-Cash/electronx-blacklist/).
 
 .. envvar:: BLACKLIST_POLL_INTERVAL
 

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -207,6 +207,29 @@ These environment variables are optional:
   version string. For example to drop versions from 1.0 to 1.2 use
   the regex ``1\.[0-2]\.\d+``.
 
+.. envvar:: BLACKLIST_URL
+
+  The URL from which to download the blacklist.json file.  This blacklist is
+  maintained by the ElectronX developers and the Bitcoin Cash server operator
+  community to provide a convenient list of currently-active phisher/sybil
+  nodes.  This mechanism has been added in April 2019 due to excessive phishing
+  and sybil attacks on the Bitcoin Cash ElectrumX/ElectronX network.  This file
+  contains a list of IP addresses (and hostname globs) to auto-ban at startup.
+  The file is refreshed from the server every 5 minutes (configurable via the
+  :envvar:`BLACKLIST_POLL_INTERVAL` variable) and any new entries are added to
+  the ban list and old entries no longer in the file are removed from the ban
+  list.  Care has been taken so that this file's ban lists do not conflict
+  with whatever you specify via the rpc 'banip' or 'banhost' commands.
+  Set this to the empty string `""` to disable this feature. Defaults to:
+  `https://www.c3-soft.com/downloads/BitcoinCash/Electron-Cash/blacklist.json`.
+
+.. envvar:: BLACKLIST_POLL_INTERVAL
+
+  The amount of time in seconds to poll BLACKLIST_URL (if non-empty string)
+  for the blacklist.json file.  Defaults to 300 seconds (5 minutes).  Setting
+  this value below 30 seconds or to a nonsensical value will result in it being
+  set to the default (300 seconds).
+
 
 Resource Usage Limits
 =====================
@@ -228,7 +251,7 @@ raise them.
 .. envvar:: MAX_SEND
 
   The maximum size of a response message to send over the wire, in
-  bytes.  Defaults to 1,000,000 (except for AuxPoW coins, which default
+  bytes.  Defaults to 4,000,000 (except for AuxPoW coins, which default
   to 10,000,000).  Values smaller than 350,000 are taken as 350,000
   because standard Electrum protocol header "chunk" requests are almost
   that large.
@@ -238,7 +261,7 @@ raise them.
   :envvar:`MAX_SEND` is a stop-gap until the protocol is improved to
   admit incremental history requests.  Each history entry is
   approximately 100 bytes so the default is equivalent to a history
-  limit of around 10,000 entries, which should be ample for most
+  limit of around 40,000 entries, which should be ample for most
   legitimate users.  If you use a higher default bear in mind one
   client can request history for multiple addresses.  Also note that
   the largest raw transaction you will be able to serve to a client is
@@ -248,19 +271,35 @@ raise them.
 
 .. envvar:: MAX_SUBS
 
-  The maximum number of address subscriptions across all sessions.
-  Defaults to 250,000.
+  The maximum number of address subscriptions across all sessions. When this
+  limit is reached, subsequent subscription requests will be met with an RPC
+  error until the subscription number gets below this limit again.
+  Defaults to 1,000,000.
 
 .. envvar:: MAX_SESSION_SUBS
 
   The maximum number of address subscriptions permitted to a single
-  session.  Defaults to 50,000.
+  session.  When this per-session limit is reached, the client will be
+  denied subsequent subscriptions. Defaults to 50,000.
+
+.. envvar:: MAX_SESSIONS_PER_IP
+
+  The maximum number of simultaneous (non-tor) client connections permitted
+  from a single IP address. If a client has more than this many connections,
+  subsequent connections will be disallowed. In addition if
+  :envvar:`BAN_EXCESSIVE_CONNECTIONS` is `1` (the default), the offending
+  client will be automatically banned. Defaults to 50.
+
+.. envvar:: BAN_EXCESSIVE_CONNECTIONS
+
+  If 1 (the default), then clients exceeding :envvar:`MAX_SESSIONS_PER_IP` will
+  be automatically banned. Defaults to 1.
 
 .. envvar:: BANDWIDTH_LIMIT
 
   Per-session periodic bandwidth usage limit in bytes.  This is a soft,
   not hard, limit.  Currently the period is hard-coded to be one hour.
-  The default limit value is 2 million bytes.
+  The default limit value is 8 million bytes.
 
   Bandwidth usage over each period is totalled, and when this limit is
   exceeded each subsequent request is stalled by sleeping before
@@ -273,6 +312,10 @@ raise them.
 
   Bandwidth usage is gradually reduced over time by "refunding" a
   proportional part of the limit every now and then.
+
+  Note from ElectronX maintainers: Despite what the above paragraphs claim,
+  there is nothing in the codebase for rate-limiting abusive clients via
+  sleep calls or any such thing.
 
 .. envvar:: SESSION_TIMEOUT
 

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -315,10 +315,6 @@ raise them.
   Bandwidth usage is gradually reduced over time by "refunding" a
   proportional part of the limit every now and then.
 
-  Note from ElectronX maintainers: Despite what the above paragraphs claim,
-  there is nothing in the codebase for rate-limiting abusive clients via
-  sleep calls or any such thing.
-
 .. envvar:: SESSION_TIMEOUT
 
   An integer number of seconds defaulting to 600.  Sessions with no

--- a/docs/rpc-interface.rst
+++ b/docs/rpc-interface.rst
@@ -26,6 +26,29 @@ connection attempt.  This command takes a single argument: the peer's
   $ electrumx_rpc add_peer "ecdsa.net v1.0 s110 t"
   "peer 'ecdsa.net v1.0 s110 t' added"
 
+banhost
+---------
+
+Ban a hostname suffix.  Banning by hostname only affects peers and does not
+ban any clients that happen to match the hostname (this is because we never
+do reverse-DNS lookups for clients).  Note that if you really want to ban bad
+actors it's recommended you ban by IP which denies the abusers access earlier
+on in the connection life cycle. Banning by hostname is a convenience for
+when scammers or sybil servers all tend to use the same domain names, and you
+want to quickly ban them all. Example usage::
+
+  $ electrumx_rpc banhost '*.scammer.com'
+  "banned peers matching suffix: scammer.com"
+
+banip
+-----
+
+Ban an IP address.  This immediately disconnects all client sessions and
+removes all peers with the specified IP address::
+
+  $ electrumx_rpc banip 10.10.100.123
+  "disconected session 15;banned 10.10.100.123"
+
 daemon_url
 ----------
 
@@ -120,6 +143,14 @@ groups
 Return a list of all current session groups.  Takes no arguments.
 
 The output is quite similar to the `sessions`_ command.
+
+listbanned
+----------
+
+Return the current ban table(s). Takes no arguments.  Note that by default
+the ban table is populated with entries from the blacklist.json file downloaded
+via :envvar:`BLACKLIST_URL`. The ban table can also be edited using the
+`banip`_ and `banhost`_ commands.
 
 log
 ---
@@ -240,5 +271,21 @@ Flush all cached data to disk and shut down the server cleanly, as if
 sending the `KILL` signal.  Be patient - during initial sync flushing
 all cached data to disk can take several minutes.  This command takes
 no arguments.
+
+unbanhost
+---------
+
+Unban a hostname suffix.  This undoes the effect of the `banhost`_ command::
+
+  $ electrumx_rpc unbanhost '*.scammer.com'
+  "unbanned peers matching suffix: scammer.com"
+
+unbanip
+-------
+
+Unban an IP address.  This undoes the effect of the `banip`_ command::
+
+  $ electrumx_rpc unbanip 10.10.100.123
+  "unbanned 10.10.100.123"
 
 .. _session logging:

--- a/electrumx/__init__.py
+++ b/electrumx/__init__.py
@@ -1,4 +1,4 @@
-version = 'ElectronX 1.9.4'
+version = 'ElectronX 1.10.0'
 version_short = version.split()[-1]
 
 from electrumx.server.controller import Controller

--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -46,7 +46,7 @@ import electrumx.lib.tx as lib_tx
 import electrumx.lib.tx_dash as lib_tx_dash
 import electrumx.server.block_processor as block_proc
 import electrumx.server.daemon as daemon
-from electrumx.server.session import (ElectrumX, DashElectrumX,
+from electrumx.server.session import (ElectrumX, ElectronX, DashElectrumX,
                                       SmartCashElectrumX, AuxPoWElectrumX)
 
 
@@ -69,7 +69,7 @@ class Coin(object):
     BASIC_HEADER_SIZE = 80
     STATIC_BLOCK_HEADERS = True
     SESSIONCLS = ElectrumX
-    DEFAULT_MAX_SEND = 1000000
+    DEFAULT_MAX_SEND = 4000000  # 4MB max response size
     DESERIALIZER = lib_tx.Deserializer
     DAEMON = daemon.Daemon
     BLOCK_PROCESSOR = block_proc.BlockProcessor
@@ -379,6 +379,7 @@ class HOdlcoin(Coin):
 class BitcoinCash(BitcoinMixin, Coin):
     NAME = "BitcoinCash"
     SHORTNAME = "BCH"
+    SESSIONCLS = ElectronX  # This is only here so the logger says ElectronX
     TX_COUNT = 246362688
     TX_COUNT_HEIGHT = 511484
     TX_PER_BLOCK = 400
@@ -403,6 +404,10 @@ class BitcoinCash(BitcoinMixin, Coin):
                     '<br/><br/>')
         return False
 
+
+class BitcoinCashABC(BitcoinCash):
+    ''' Compatibility with ElectrumX's broken naming scheme. '''
+    NAME = "BitcoinCashABC"
 
 class BitcoinSegwit(BitcoinMixin, Coin):
     NAME = "BitcoinSegwit"
@@ -590,6 +595,7 @@ class BitcoinCashTestnet(BitcoinTestnetMixin, Coin):
         'testnet.imaginary.cash t50001 s50002',
         'blackie.c3-soft.com t60001 s60002',
     ]
+    SESSIONCLS = ElectronX  # This is here for the logger, really
 
     @classmethod
     def upgrade_required(cls, client_ver):
@@ -602,6 +608,9 @@ class BitcoinCashTestnet(BitcoinTestnetMixin, Coin):
                     '<br/><br/>')
         return False
 
+class BitcoinCashTestnetABC(BitcoinCashTestnet):
+    ''' Compatibility with ElectrumX's broken naming scheme. '''
+    NAME = "BitcoinCashABC"
 
 class BitcoinCashRegtest(BitcoinCashTestnet):
     NAME = "BitcoinCash"

--- a/electrumx/lib/util.py
+++ b/electrumx/lib/util.py
@@ -280,8 +280,9 @@ def protocol_tuple(s):
 
     If the version number is bad, (0, ) indicating version 0 is returned.'''
     try:
-        # clean up extra text at end of version e.g. '3.3.4CS' -> '3.3.4'
-        s = VERSION_CLEANUP_REGEX.match(s).group(1)
+        # clean up extra text at end of version e.g. '3.3.4CS' -> '3.3.4',
+        # 'electrum/3.3.4' -> '3.3.4', etc
+        s = ''.join(VERSION_CLEANUP_REGEX.findall(s))
         return tuple(int(part) for part in s.split('.'))
     except Exception:
         return (0, )

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -209,9 +209,9 @@ class BlockProcessor(object):
             await self._maybe_flush()
             if not self.db.first_sync:
                 s = '' if len(blocks) == 1 else 's'
-                self.logger.info('processed {:,d} block{} in {:.1f}s'
-                                 .format(len(blocks), s,
-                                         time.time() - start))
+                blocks_size = sum(len(block) for block in raw_blocks) / 1_000_000
+                self.logger.info(f'processed {len(blocks):,d} block{s} size {blocks_size:.2f} MB '
+                                 f'in {time.time() - start:.1f}s')
             if self._caught_up_event.is_set():
                 await self.notifications.on_block(self.touched, self.height)
             self.touched = set()

--- a/electrumx/server/env.py
+++ b/electrumx/server/env.py
@@ -53,7 +53,6 @@ class Env(EnvBase):
             self.ssl_certfile = self.required('SSL_CERTFILE')
             self.ssl_keyfile = self.required('SSL_KEYFILE')
         self.rpc_port = self.integer('RPC_PORT', 8000)
-        self.max_subscriptions = self.integer('MAX_SUBSCRIPTIONS', 10000)
         self.banner_file = self.default('BANNER_FILE', None)
         self.tor_banner_file = self.default('TOR_BANNER_FILE',
                                             self.banner_file)
@@ -69,12 +68,22 @@ class Env(EnvBase):
         self.donation_address = self.default('DONATION_ADDRESS', '')
         # Server limits to help prevent DoS
         self.max_send = self.integer('MAX_SEND', self.coin.DEFAULT_MAX_SEND)
-        self.max_subs = self.integer('MAX_SUBS', 250000)
+        self.max_subs = self.integer('MAX_SUBS', 1000000)
         self.max_sessions = self.sane_max_sessions()
+        self.max_sessions_per_ip = self.integer('MAX_SESSIONS_PER_IP', 50)
         self.max_session_subs = self.integer('MAX_SESSION_SUBS', 50000)
-        self.bandwidth_limit = self.integer('BANDWIDTH_LIMIT', 2000000)
+        self.bandwidth_limit = self.integer('BANDWIDTH_LIMIT', 8000000)
         self.session_timeout = self.integer('SESSION_TIMEOUT', 600)
         self.drop_client = self.custom("DROP_CLIENT", None, re.compile)
+        # Blacklist URL. Set this to the empty string in the environment if you want to disable this facility
+        self.blacklist_url = self.default('BLACKLIST_URL',
+                                          'https://www.c3-soft.com/downloads/BitcoinCash/Electron-Cash/blacklist.json'
+                                          )
+        self.blacklist_poll_interval = self.custom('BLACKLIST_POLL_INTERVAL', 300,
+                                                   # parse as integer and limit it to >= 30 secs and <= 86400 (1 day)
+                                                   lambda x: (int(x) >= 30 and int(x) <= 86400 and int(x)) or 300)
+        # If this is set, then we ban whenever an IP address has more than self.max_sessions_per_ip connections
+        self.ban_excessive_connections = self.boolean('BAN_EXCESSIVE_CONNECTIONS', True)
 
         # Identities
         clearnet_identity = self.clearnet_identity()

--- a/electrumx/server/env.py
+++ b/electrumx/server/env.py
@@ -77,7 +77,7 @@ class Env(EnvBase):
         self.drop_client = self.custom("DROP_CLIENT", None, re.compile)
         # Blacklist URL. Set this to the empty string in the environment if you want to disable this facility
         self.blacklist_url = self.default('BLACKLIST_URL',
-                                          'https://www.c3-soft.com/downloads/BitcoinCash/Electron-Cash/blacklist.json'
+                                          'https://raw.githubusercontent.com/Electron-Cash/electronx-blacklist/master/blacklist.json'
                                           )
         self.blacklist_poll_interval = self.custom('BLACKLIST_POLL_INTERVAL', 300,
                                                    # parse as integer and limit it to >= 30 secs and <= 86400 (1 day)

--- a/electrumx/server/peers.py
+++ b/electrumx/server/peers.py
@@ -289,6 +289,8 @@ class PeerManager(object):
         return False
 
     def _dupes_for_peer(self, peer_ip_addr):
+        ''' Note: peer_ip_addr in this case is an ip address string as returned
+        from getaddrinfo and not a Python ip_address object. '''
         dupes = [p for p in self.peers.copy() if p.last_good and not p.bad and not p.is_tor and p.ip_addr == peer_ip_addr]
         return dupes
 

--- a/electrumx_rpc
+++ b/electrumx_rpc
@@ -22,6 +22,7 @@ import electrumx.lib.text as text
 simple_commands = {
     'getinfo': 'Print a summary of server state',
     'groups': 'Print current session groups',
+    'listbanned': "Show the list of banned IPs and hostname globs",
     'peers': 'Print information about peer servers for the same coin',
     'sessions': 'Print information about client sessions',
     'stop': 'Shut down the server cleanly',
@@ -39,6 +40,22 @@ other_commands = {
             'type': str,
             'dest': 'real_name',
             'help': 'e.g. "a.domain.name s995 t"',
+        },
+    ),
+    'banhost': (
+        'ban an hostname or hostname glob (applied to peers only)',
+        [], {
+            'type': str,
+            'dest': 'host',
+            'help': 'e.g. "*.somedomain.com"',
+        },
+    ),
+    'banip': (
+        'ban an IP address (session or peer)',
+        [], {
+            'type': str,
+            'dest': 'ip',
+            'help': 'e.g. "10.11.12.123"',
         },
     ),
     'daemon_url': (
@@ -71,6 +88,22 @@ other_commands = {
             'dest': 'count',
             'default': 3,
             'help': 'number of blocks to back up'
+        },
+    ),
+    'unbanhost': (
+        'un-ban a host in the host banlist (applied to peers only)',
+        [], {
+            'type': str,
+            'dest': 'host',
+            'help': 'e.g. "*.somedomain.com"',
+        },
+    ),
+    'unbanip': (
+        'un-ban an IP address (session or peer)',
+        [], {
+            'type': str,
+            'dest': 'ip',
+            'help': 'e.g. "10.11.12.123"',
         },
     ),
 }

--- a/electrumx_rpc
+++ b/electrumx_rpc
@@ -43,7 +43,7 @@ other_commands = {
         },
     ),
     'banhost': (
-        'ban an hostname or hostname glob (applied to peers only)',
+        'ban a hostname or hostname glob (applied to peers only)',
         [], {
             'type': str,
             'dest': 'host',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import setuptools
-version = '1.9.4'
+version = '1.10.0'
 
 setuptools.setup(
     name='electronX',

--- a/tests/server/test_env.py
+++ b/tests/server/test_env.py
@@ -210,7 +210,7 @@ def test_DB_ENGINE():
 
 
 def test_MAX_SEND():
-    assert_integer('MAX_SEND', 'max_send', 1000000)
+    assert_integer('MAX_SEND', 'max_send', 4000000)
 
 
 def test_MAX_SUBS():
@@ -218,7 +218,7 @@ def test_MAX_SUBS():
 
 
 def test_MAX_SESSIONS():
-    too_big = 1000000
+    too_big = 10000000
     os.environ['MAX_SESSIONS'] = str(too_big)
     e = Env()
     assert e.max_sessions < too_big
@@ -230,7 +230,7 @@ def test_MAX_SESSION_SUBS():
 
 
 def test_BANDWIDTH_LIMIT():
-    assert_integer('BANDWIDTH_LIMIT', 'bandwidth_limit', 2000000)
+    assert_integer('BANDWIDTH_LIMIT', 'bandwidth_limit', 8000000)
 
 
 def test_SESSION_TIMEOUT():

--- a/tests/server/test_env.py
+++ b/tests/server/test_env.py
@@ -196,9 +196,6 @@ def test_RPC_PORT():
     assert_integer('RPC_PORT', 'rpc_port', 8000)
 
 
-def test_MAX_SUBSCRIPTIONS():
-    assert_integer('MAX_SUBSCRIPTIONS', 'max_subscriptions', 10000)
-
 
 def test_LOG_SESSIONS():
     assert_integer('LOG_SESSIONS', 'log_sessions', 3600)
@@ -217,7 +214,7 @@ def test_MAX_SEND():
 
 
 def test_MAX_SUBS():
-    assert_integer('MAX_SUBS', 'max_subs', 250000)
+    assert_integer('MAX_SUBS', 'max_subs', 1000000)
 
 
 def test_MAX_SESSIONS():


### PR DESCRIPTION
* Added banip, unbanip, banhost, unbanhost and listbanned rpc commands (cculianu)
* Disallow multiple servers from same IP to appear in peers (doesn't apply
  to Tor, however) (cculianu)
* Limit client connections per IP to 50 by default (MAX_SESSIONS_PER_IP)
  to prevent the "clients exhausting FDs on server" attack vector.
  (cculianu)
* Added blacklist.json mechanism for downloading a community maintained
  list of bad peers as an anti-phishing, anti-sybil attack measure.
  Use BLACKLIST_URL="" in env to disable, but it is recommended you leave
  it enabled.  We use our own file format for this but the code for this
  subsystem also understand the ElectrumX 1.10.0 format as well. (cculianu)
* Set MAX_SEND to 4000000 (4MB) by default (was originally 1MB which fails
  on some BCH wallets). (cculianu)
* Raised server limit from 250,000 subs to 1,000,000 subs by default
  (corresponds to env var MAX_SUBS) (cculianu)
* Raised default BANDWIDTH_LIMIT from 2MB to 8MB (8000000 bytes).  This is
  because very busy BCH wallets with huge histories would need a higher limit.
  Note the limit is a soft limit in bytes per hour, and it is not catastrophic
  to send a client 8MB in 1 hour.  Also note that ElectrumX currently does
  nothing with this limit despite what the documentation claims. (cculianu)